### PR TITLE
don't install atmos wrapper

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,7 @@ runs:
        ATMOS_CLI_CONFIG_PATH: ${{inputs.atmos-config-path}}
       with:
         atmos-version: ${{ inputs.atmos-version }}
+        install-wrapper: false
 
     - if: ${{ inputs.install-jq == 'true' }}
       uses: dcarbone/install-jq-action@v1.0.1


### PR DESCRIPTION
## what

Don't install the node-based wrapper with atmos

## why

It isn't necessary for this action and causes issues when the runner doesn't have `node` installed