### PR TITLE
Added major release tagger

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,12 @@
+name: release-published
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cloudposse/github-action-major-release-tagger@v1


### PR DESCRIPTION
## what
* Added major release tagger github action that will manager `v` tags.

## why
* Added major release tagger github action that will manager `v` tags.

## references
* https://github.com/cloudposse/github-action-major-release-tagger
