### PR TITLE
bugfix: workflow empty stacks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,10 +54,10 @@ outputs:
     value: ${{ steps.affected.outputs.affected }}
   has-affected-stacks:
     description: Whether there are affected stacks
-    value: ${{ steps.matrix.outputs.matrix != '{"include":[]}' }}
+    value: ${{ steps.affected.outputs.has-affected-stacks }}
   matrix:
     description: The affected stacks as matrix structure suitable for extending matrix size workaround (see README)
-    value: ${{ steps.matrix.outputs.matrix != '{"include":[]}' && steps.matrix.outputs.matrix || '{"include":["foo":"bar"]}' }}
+    value: ${{ steps.matrix.outputs.matrix }}
 
 runs:
   using: "composite"
@@ -122,6 +122,12 @@ runs:
           atmos describe affected --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/main-branch"
         fi
         affected=$(jq -c '.' affected-stacks.json)
+        if [[ "$affected" == "[]" ]]; then
+          echo '[{"component": "None", "stack": "None", "stack-slug": "None"]' > affected-stacks.json
+          echo "has-affected-stacks=false" >> $GITHUB_OUTPUT 
+        else
+          echo "has-affected-stacks=true" >> $GITHUB_OUTPUT 
+        fi
         printf "%s" "affected=$affected" >> $GITHUB_OUTPUT
 
     - uses: cloudposse/github-action-matrix-extended@v0

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ outputs:
     value: ${{ steps.matrix.outputs.matrix != '{"include":[]}' }}
   matrix:
     description: The affected stacks as matrix structure suitable for extending matrix size workaround (see README)
-    value: ${{ steps.matrix.outputs.matrix }}
+    value: ${{ steps.matrix.outputs.matrix != '{"include":[]}' && steps.matrix.outputs.matrix || '{"include":["foo":"bar"]}' }}
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         fi
         affected=$(jq -c '.' affected-stacks.json)
         if [[ "$affected" == "[]" ]]; then
-          echo '[{"component": "None", "stack": "None", "stack-slug": "None"}]' > affected-stacks.json
+          echo '[{"component": "none", "stack": "none", "stack_slug": "none"}]' > affected-stacks.json
           echo "has-affected-stacks=false" >> $GITHUB_OUTPUT 
         else
           echo "has-affected-stacks=true" >> $GITHUB_OUTPUT 

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         fi
         affected=$(jq -c '.' affected-stacks.json)
         if [[ "$affected" == "[]" ]]; then
-          echo '[{"component": "None", "stack": "None", "stack-slug": "None"]' > affected-stacks.json
+          echo '[{"component": "None", "stack": "None", "stack-slug": "None"}]' > affected-stacks.json
           echo "has-affected-stacks=false" >> $GITHUB_OUTPUT 
         else
           echo "has-affected-stacks=true" >> $GITHUB_OUTPUT 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ outputs:
     value: ${{ steps.affected.outputs.affected }}
   has-affected-stacks:
     description: Whether there are affected stacks
-    value: ${{ steps.affected.outputs.has-affected-stacks }}
+    value: ${{ steps.affected.outputs.has-affected-stacks == 'true' }}
   matrix:
     description: The affected stacks as matrix structure suitable for extending matrix size workaround (see README)
     value: ${{ steps.matrix.outputs.matrix }}
@@ -124,7 +124,7 @@ runs:
         affected=$(jq -c '.' affected-stacks.json)
         if [[ "$affected" == "[]" ]]; then
           echo '[{"component": "none", "stack": "none", "stack_slug": "none"}]' > affected-stacks.json
-          echo "has-affected-stacks=''" >> $GITHUB_OUTPUT 
+          echo "has-affected-stacks=false" >> $GITHUB_OUTPUT 
         else
           echo "has-affected-stacks=true" >> $GITHUB_OUTPUT 
         fi

--- a/action.yml
+++ b/action.yml
@@ -124,7 +124,7 @@ runs:
         affected=$(jq -c '.' affected-stacks.json)
         if [[ "$affected" == "[]" ]]; then
           echo '[{"component": "none", "stack": "none", "stack_slug": "none"}]' > affected-stacks.json
-          echo "has-affected-stacks=false" >> $GITHUB_OUTPUT 
+          echo "has-affected-stacks=''" >> $GITHUB_OUTPUT 
         else
           echo "has-affected-stacks=true" >> $GITHUB_OUTPUT 
         fi


### PR DESCRIPTION
## what
* If no affected stacks, return a valid includes matrix structure

## why
* Job failed if no affected stacks, despite all steps succeeding
