### PR TITLE
feat: add IAM auth support (required for stack config templating as of atmos `1.18.2`)

### DIFF
--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           cache: true
           config: |-
-            mikefarah/yq:v4.44.3
+            mikefarah/yq: v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -33,10 +33,15 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH
+
+      - uses: cloudposse-github-actions/install-gh-releases@v1
+        with:
+          cache: true
+          config: |-
+            mikefarah/yq:v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -33,6 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - shell: bash
         run: |

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -7,6 +7,10 @@ on:
 #  pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -22,16 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH
 
       - uses: ./
         id: current
         with:
-          iam-auth-enabled: false
           install-atmos: false
-          atmos-config-path: "./tests"
           nested-matrices-count: '2'
+          atmos-config-path: ${{ runner.temp }}
 
     outputs:
       affected: "${{ steps.current.outputs.affected }}"

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: ./
         id: current
         with:
+          iam-auth-enabled: false
           install-atmos: false
           atmos-config-path: "./tests"
           nested-matrices-count: '2'

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           cache: true
           config: |-
-            mikefarah/yq:v4.44.3
+            mikefarah/yq: v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -33,10 +33,15 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH
+
+      - uses: cloudposse-github-actions/install-gh-releases@v1
+        with:
+          cache: true
+          config: |-
+            mikefarah/yq:v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -33,6 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - shell: bash
         run: |

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: ./
         id: current
         with:
+          iam-auth-enabled: false
           install-atmos: false
           atmos-config-path: "./tests"
           nested-matrices-count: '3'

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -7,6 +7,10 @@ on:
 #  pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -22,16 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH
 
       - uses: ./
         id: current
         with:
-          iam-auth-enabled: false
           install-atmos: false
-          atmos-config-path: "./tests"
           nested-matrices-count: '3'
+          atmos-config-path: ${{ runner.temp }}
 
     outputs:
       affected: "${{ steps.current.outputs.affected }}"

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - shell: bash
         run: |

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: ./
         id: current
         with:
+          iam-auth-enabled: false
           install-atmos: true
           atmos-config-path: "./tests"
 

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -33,6 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
 
       - uses: ./
         id: current

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - uses: ./
         id: current

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -33,7 +33,12 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
+
+      - uses: cloudposse-github-actions/install-gh-releases@v1
+        with:
+          cache: true
+          config: |-
+            mikefarah/yq:v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -7,6 +7,10 @@ on:
   # pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -22,12 +26,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - uses: ./
         id: current
         with:
-          iam-auth-enabled: false
           install-atmos: true
-          atmos-config-path: "./tests"
+          atmos-config-path: ${{ runner.temp }}
 
     outputs:
       affected: "${{ steps.current.outputs.affected }}"

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           cache: true
           config: |-
-            mikefarah/yq:v4.44.3
+            mikefarah/yq: v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           cache: true
           config: |-
-            mikefarah/yq:v4.44.3
+            mikefarah/yq: v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -33,10 +33,15 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH
+
+      - uses: cloudposse-github-actions/install-gh-releases@v1
+        with:
+          cache: true
+          config: |-
+            mikefarah/yq:v4.44.3
 
       - uses: ./
         id: current

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -7,6 +7,10 @@ on:
   # pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -22,15 +26,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - shell: bash
+        run: |
+          mkdir -p ${{ runner.temp }}
+          cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH
 
       - uses: ./
         id: current
         with:
-          iam-auth-enabled: false
           install-atmos: false
-          atmos-config-path: "./tests"
+          atmos-config-path: ${{ runner.temp }}
 
     outputs:
       affected: "${{ steps.current.outputs.affected }}"

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
-          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./tests/fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -33,6 +33,7 @@ jobs:
           mkdir -p ${{ runner.temp }}
           cp ./tests/atmos.yaml ${{ runner.temp }}/atmos.yaml
           sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ${{ runner.temp }}/atmos.yaml
+          sed -i -e 's#__PLAN_ROLE__#${{ secrets.TERRAFORM_PLAN_ROLE }}#g' ./fixtures/atmos
 
       - name: add mock atmos to the path
         run: echo "./tests/fixtures" >> $GITHUB_PATH

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: ./
         id: current
         with:
+          iam-auth-enabled: false
           install-atmos: false
           atmos-config-path: "./tests"
 

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - shell: bash
         run: |

--- a/action.yml
+++ b/action.yml
@@ -112,6 +112,11 @@ runs:
         echo "terraform-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["terraform-version"]')" >> $GITHUB_OUTPUT      
         echo "group-by=$(atmos describe config -f json | jq -r '.integrations.github.gitops.matrix["group-by"]')" >> $GITHUB_OUTPUT
         echo "sort-by=$(atmos describe config -f json | jq -r '.integrations.github.gitops.matrix["sort-by"]')" >> $GITHUB_OUTPUT
+        echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
+        echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
+        echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
+        echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
+        echo "terraform-plan-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops.role.plan')" >> $GITHUB_OUTPUT
 
     - name: Install Terraform
       if: ${{ steps.config.outputs.terraform-version != '' && steps.config.outputs.terraform-version != 'null' }}
@@ -142,6 +147,14 @@ runs:
       shell: bash
       run: git checkout ${{ inputs.base-ref }}
       working-directory: base-ref
+
+    - name: Configure Plan AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4.0.2
+      with:
+        aws-region: ${{ steps.config.outputs.aws-region }}
+        role-to-assume: ${{ steps.config.outputs.terraform-plan-role }}
+        role-session-name: "atmos-terraform-plan-gitops"
+        mask-aws-account-id: "no"
 
     - name: atmos affected stacks for atmos pro
       id: affected-pro

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: Whether to include dependents of affected stacks in the output
     required: false
     default: "false"
+  iam-auth-enabled:
+    description: Whether to assume the Terraform plan IAM role prior to running atmos commands
+    required: false
+    default: "true"
   install-jq:
     description: Whether to install jq
     required: false
@@ -113,9 +117,6 @@ runs:
         echo "group-by=$(atmos describe config -f json | jq -r '.integrations.github.gitops.matrix["group-by"]')" >> $GITHUB_OUTPUT
         echo "sort-by=$(atmos describe config -f json | jq -r '.integrations.github.gitops.matrix["sort-by"]')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
-        echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
-        echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
-        echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
         echo "terraform-plan-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops.role.plan')" >> $GITHUB_OUTPUT
 
     - name: Install Terraform
@@ -149,6 +150,7 @@ runs:
       working-directory: base-ref
 
     - name: Configure Plan AWS Credentials
+      if: ${{ inputs.iam-auth-enabled == 'true' }}
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}

--- a/action.yml
+++ b/action.yml
@@ -47,10 +47,6 @@ inputs:
     description: Whether to include dependents of affected stacks in the output
     required: false
     default: "false"
-  iam-auth-enabled:
-    description: Whether to assume the Terraform plan IAM role prior to running atmos commands
-    required: false
-    default: "true"
   install-jq:
     description: Whether to install jq
     required: false
@@ -150,7 +146,6 @@ runs:
       working-directory: base-ref
 
     - name: Configure Plan AWS Credentials
-      if: ${{ inputs.iam-auth-enabled == 'true' }}
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}

--- a/tests/atmos.yaml
+++ b/tests/atmos.yaml
@@ -257,7 +257,7 @@ integrations:
         table: cptest-core-ue2-auto-gitops-plan-storage
         role: arn:aws:iam::xxxxxxxxxxxx:role/cptest-core-ue2-auto-gitops-gha
       role:
-        plan: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
+        plan: __PLAN_ROLE__
         apply: arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops
       matrix:
         sort-by: .stack_slug

--- a/tests/fixtures/atmos
+++ b/tests/fixtures/atmos
@@ -1,35 +1,4 @@
 #!/bin/bash
 
 cat "${GITHUB_ACTION_PATH}/tests/fixtures/mock-atmos-describe-affected.json" > affected-stacks.json
-
-cat << EOF
-{
-   "integrations": {
-      "atlantis": {
-
-      },
-      "github": {
-         "gitops": {
-						"infracost-enabled": false,
-						"matrix": {
-							"group-by": ".stack_slug | split(\"-\") | [.[0], .[2]] | join(\"-\")",
-							"sort-by": ".stack_slug"
-						},
-						"role": {
-							"apply": "arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops",
-							"plan": "arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops"
-						},
-						"artifact-storage": {
-							"bucket": "cptest-core-ue2-auto-gitops",
-							"region": "us-east-2",
-							"role": "__PLAN_ROLE__",
-							"table": "cptest-core-ue2-auto-gitops-plan-storage"
-						},
-						"terraform-version": "1.5.2"
-				}
-			}
-   }
-}
-
-
-EOF
+cat ${ATMOS_CLI_CONFIG_PATH}/atmos.yaml | yq e --tojson '.' -

--- a/tests/fixtures/atmos
+++ b/tests/fixtures/atmos
@@ -19,10 +19,10 @@ cat << EOF
 							"apply": "arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops",
 							"plan": "arn:aws:iam::yyyyyyyyyyyy:role/cptest-core-gbl-identity-gitops"
 						},
-						"storage": {
+						"artifact-storage": {
 							"bucket": "cptest-core-ue2-auto-gitops",
 							"region": "us-east-2",
-							"role": "arn:aws:iam::xxxxxxxxxxxx:role/cptest-core-ue2-auto-gitops-gha",
+							"role": "__PLAN_ROLE__",
 							"table": "cptest-core-ue2-auto-gitops-plan-storage"
 						},
 						"terraform-version": "1.5.2"


### PR DESCRIPTION
## what

* Add IAM auth support

## why

* IAM auth is required for stack config templating as of atmos `1.18.2`

## references

* https://github.com/cloudposse/atmos/releases/tag/v1.86.2

## Notes

~I am not quite sure if `Configure Plan AWS Credentials` should be controlled by a condition. In [cloudposse/github-action-atmos-terraform-plan](https://github.com/cloudposse/github-action-atmos-terraform-plan/blob/a40b1dd4cd021aa6c2273ff6e77949263f37acc7/action.yml#L189-L196), it is controlled by the outputs of [cloudposse/github-action-atmos-get-setting](https://github.com/cloudposse/github-action-atmos-get-setting). But we cannot use that action within this composite action, as the former is specific to one stack/component, whereas the latter (this repo) is not.~ (EDIT: it's definitely a requirement to put that step behind a condition — https://github.com/cloudposse/github-action-atmos-affected-stacks/actions/runs/10458450730)

~I've added additional outputs to `config`, most of which are not referenced at all. However I did this in order to be consistent with `cloudposse/github-action-atmos-terraform-plan`.~