### PR TITLE
Skip AWS auth if Gitops aws configuration empty in atmos settings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -150,6 +150,10 @@ runs:
       working-directory: base-ref
 
     - name: Configure Plan AWS Credentials
+      if: ${{ steps.config.outputs.aws-region != '' && 
+              steps.config.outputs.aws-region != 'null' && 
+              steps.config.outputs.terraform-plan-role != '' && 
+              steps.config.outputs.terraform-plan-role != 'null' }}
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}


### PR DESCRIPTION
## what
* Skip AWS auth if Gitops aws configuration empty in atmos settings

## Why
* Allow to skip AWS auth and use an external one
* Make the action cloud agnostic

## Example 
If `atmos.yaml` contains

```yaml
integrations:
  github:
    gitops:
      opentofu-version: 1.7.3    
      terraform-version: 1.5.7
      infracost-enabled: false
      artifact-storage:
        region: us-east-2
        bucket: cptest-core-ue2-auto-gitops
        table: cptest-core-ue2-auto-gitops-plan-storage
        role: arn:aws:iam::461333128641:role/cptest-core-ue2-auto-gha-iam-gitops-gha
# here used to be
#      role:
#        plan: arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planners
#        apply: arn:aws:iam::582055374050:role/cptest-core-gbl-identity-gitops
      matrix:
        sort-by: .stack_slug
        group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")

```

