### PR TITLE
fix: replace context with default var (#52)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -190,7 +190,7 @@ runs:
       if: ${{ inputs.atmos-pro-upload == 'false' && steps.affected.outputs.affected == '[]' }}
       shell: bash
       run: |-
-        cat ${{ github.action_path }}/assets/summary.md >> $GITHUB_STEP_SUMMARY
+        cat "${GITHUB_ACTION_PATH}/assets/summary.md" >> $GITHUB_STEP_SUMMARY
 
     - uses: cloudposse/github-action-matrix-extended@v0
       id: matrix


### PR DESCRIPTION
## what
- Replace context with default variable

## why
- When using container within GitHub Actions, context value is incorrect. Default variable value remains correct.
- As github.action_path is used during step execution (within runner), it can be replaced by default variable.

## references
* https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/52
* There are more reported issues showing this problem in various scenarios, for instance [this one](https://github.com/actions/runner/issues/716#issuecomment-1494213926)
