### PR TITLE
chore: Option to Skip Atmos Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Which would produce the same behavior as in `v1`, doing this:
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.7 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
+| skip-atmos-functions | Skip all Atmos functions such as terraform.output | false | false |
 | skip-checkout | Disable actions/checkout for head-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions | false | false |
 
 
@@ -511,7 +512,7 @@ All other trademarks referenced herein are the property of their respective owne
 
 
 ---
-Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/github-action-atmos-affected-stacks&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,10 @@ inputs:
     required: false
     description: "Number of nested matrices that should be returned as the output (from 1 to 3)"
     default: "2"
+  skip-atmos-functions:
+    required: false
+    description: "Skip all Atmos functions such as terraform.output"
+    default: "false"
   
 outputs:
   affected:
@@ -197,6 +201,10 @@ runs:
         
         if [[ -n "${{ inputs.atmos-stack }}" ]]; then
           base_cmd+=" --stack=${{ inputs.atmos-stack }}"
+        fi
+
+        if [[ "${{ inputs.skip-atmos-functions }}" == "true" ]]; then
+          base_cmd+=" --skip=terraform.output"
         fi
         
         eval "$base_cmd"

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -21,6 +21,7 @@
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.7 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
+| skip-atmos-functions | Skip all Atmos functions such as terraform.output | false | false |
 | skip-checkout | Disable actions/checkout for head-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions | false | false |
 
 

--- a/tests/atmos.yaml
+++ b/tests/atmos.yaml
@@ -64,7 +64,9 @@ workflows:
 
 logs:
   verbose: false
-  colors: true
+  colors: false
+  level: Trace
+  file: "/tmp/atmos.log"
 
 # Custom CLI commands
 commands:


### PR DESCRIPTION
## what
- Added `skip-atmos-functions` input

## why
- When `skip-atmos-functions` is true, we can skip all atmos functions. This is necessary if we do not have AWS permission in GH actions

## references
- n/a
