### PR TITLE
Add process templates option to GitHub Action parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Which would produce the same behavior as in `v1`, doing this:
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.7 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
+| process-templates | Whether to process templates | true | false |
 | skip-atmos-functions | Skip all Atmos functions such as terraform.output | false | false |
 | skip-checkout | Disable actions/checkout for head-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions | false | false |
 

--- a/action.yml
+++ b/action.yml
@@ -75,11 +75,15 @@ inputs:
     required: false
     description: "Number of nested matrices that should be returned as the output (from 1 to 3)"
     default: "2"
+  process-templates:
+    required: false
+    description: "Whether to process templates"
+    default: "true"    
   skip-atmos-functions:
     required: false
     description: "Skip all Atmos functions such as terraform.output"
     default: "false"
-  
+      
 outputs:
   affected:
     description: The affected stacks
@@ -207,6 +211,9 @@ runs:
           base_cmd+=" --skip=terraform.output"
         fi
         
+        if [[ "${{ inputs.process-templates }}" == "false" ]]; then
+          base_cmd+=" --process-templates=false"
+        fi
         eval "$base_cmd"
         affected=$(jq -c '.' affected-stacks.json)
         printf "%s" "affected=$affected" >> $GITHUB_OUTPUT

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -21,6 +21,7 @@
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.7 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
+| process-templates | Whether to process templates | true | false |
 | skip-atmos-functions | Skip all Atmos functions such as terraform.output | false | false |
 | skip-checkout | Disable actions/checkout for head-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions | false | false |
 


### PR DESCRIPTION
## what
* Added `process-templates `input

## why
* When `process-templates` is false, we can avoid processing the go templates when running the describe command. This is necessary if certain go templates have references that are not configured for GH actions

## references
* https://atmos.tools/cli/commands/describe/component/#flags:~:text=no-,%2D%2Dprocess%2Dtemplates,-Enable/disable%20processing
