### PR TITLE
Add process functions option to GitHub Action parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ Which would produce the same behavior as in `v1`, doing this:
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.7 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
+| process-functions | Whether to process functions | true | false |
 | process-templates | Whether to process templates | true | false |
 | skip-atmos-functions | Skip all Atmos functions such as terraform.output | false | false |
 | skip-checkout | Disable actions/checkout for head-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions | false | false |

--- a/action.yml
+++ b/action.yml
@@ -214,6 +214,10 @@ runs:
         if [[ "${{ inputs.process-templates }}" == "false" ]]; then
           base_cmd+=" --process-templates=false"
         fi
+
+        if [[ "${{ inputs.process-functions }}" == "false" ]]; then
+          base_cmd+=" --process-functions=false"
+        fi        
         eval "$base_cmd"
         affected=$(jq -c '.' affected-stacks.json)
         printf "%s" "affected=$affected" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,10 @@ inputs:
     required: false
     description: "Number of nested matrices that should be returned as the output (from 1 to 3)"
     default: "2"
+  process-functions:
+    required: false
+    description: "Whether to process functions"
+    default: true
   process-templates:
     required: false
     description: "Whether to process templates"

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -21,6 +21,7 @@
 | jq-force | Whether to force the installation of jq | true | false |
 | jq-version | The version of jq to install if install-jq is true | 1.7 | false |
 | nested-matrices-count | Number of nested matrices that should be returned as the output (from 1 to 3) | 2 | false |
+| process-functions | Whether to process functions | true | false |
 | process-templates | Whether to process templates | true | false |
 | skip-atmos-functions | Skip all Atmos functions such as terraform.output | false | false |
 | skip-checkout | Disable actions/checkout for head-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions | false | false |


### PR DESCRIPTION
## what
* Added `process-functions` input

## why
* When process-functions is false, we can avoid processing the yaml functions. Values retrieved via the !store commands don't always need to be retrieved when calling  `atmos describe affected` so exposing this flag allows it to be toggled off. 

## references
* [https://atmos.tools/cli/commands/describe/component/#:~:text=no-,%2D%2Dprocess%2Dfunctions,-Enable/disable%20processing](https://atmos.tools/cli/commands/describe/component/#:~:text=no-,%2D%2Dprocess%2Dfunctions,-Enable/disable%20processing)
