### PR TITLE
Add skip-checkout to base-ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -181,13 +181,19 @@ runs:
       if: ${{ inputs.atmos-pro-upload == 'false' }}
       shell: bash
       run: |
+        base_cmd="atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path \"$GITHUB_WORKSPACE/base-ref\""
+        
         if [[ "${{ inputs.atmos-include-spacelift-admin-stacks }}" == "true" ]]; then
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-spacelift-admin-stacks=true --stack=${{ inputs.atmos-stack }}
+          base_cmd+=" --include-spacelift-admin-stacks=true"
         elif [[ "${{ inputs.atmos-include-dependents }}" == "true" ]]; then
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-dependents=true --stack=${{ inputs.atmos-stack }}
-        else
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --stack=${{ inputs.atmos-stack }}
+          base_cmd+=" --include-dependents=true"
         fi
+        
+        if [[ -n "${{ inputs.atmos-stack }}" ]]; then
+          base_cmd+=" --stack=${{ inputs.atmos-stack }}"
+        fi
+        
+        eval "$base_cmd"
         affected=$(jq -c '.' affected-stacks.json)
         printf "%s" "affected=$affected" >> $GITHUB_OUTPUT
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   atmos-version:
     description: The version of atmos to install
     required: false
-    default: ">= 1.92.0"
+    default: ">= 1.96.0"
   atmos-config-path:
     description: The path to the atmos.yaml file
     required: true

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   skip-checkout:
     description: "Disable actions/checkout for head-ref and base-ref. Useful for when the checkout happens in a previous step and file are modified outside of git through other actions"
     required: false
-    default: 'false'    
+    default: "false"
   default-branch:
     description: The default branch to use for the base ref.
     required: false
@@ -82,7 +82,7 @@ inputs:
   process-templates:
     required: false
     description: "Whether to process atmos templates"
-    default: "true"    
+    default: "true"
   skip-atmos-functions:
     required: false
     description: "Skip all Atmos functions such as terraform.output"
@@ -91,7 +91,7 @@ inputs:
     required: false
     description: "Whether to enable the verbose mode of the Atmos commands"
     default: "true"
-      
+
 outputs:
   affected:
     description: The affected stacks
@@ -102,7 +102,6 @@ outputs:
   matrix:
     description: The affected stacks as matrix structure suitable for extending matrix size workaround (see README)
     value: ${{ steps.matrix.outputs.matrix }}
-
 
 runs:
   using: "composite"
@@ -118,7 +117,7 @@ runs:
         ref: ${{ inputs.head-ref }}
 
     - uses: cloudposse-github-actions/install-gh-releases@v1
-      if: ${{ inputs.install-jq == 'true' }}    
+      if: ${{ inputs.install-jq == 'true' }}
       with:
         cache: true
         config: |-
@@ -165,6 +164,7 @@ runs:
     # current branch to it to determine the affected stacks. This is different from a file-based git diff in that we
     # look at the contents of the stack files to determine if any have changed.
     - uses: actions/checkout@v4
+      if: ${{ inputs.skip-checkout != 'true' }}
       with:
         ref: ${{ inputs.default-branch }}
         path: base-ref
@@ -173,14 +173,14 @@ runs:
     - name: checkout base ref
       id: base-ref
       shell: bash
-      run: git checkout ${{ inputs.base-ref }}
+      run: git checkout ${{ inputs.skip-checkout == 'true' && '-f' || '' }} ${{ inputs.base-ref }}
       working-directory: base-ref
 
     - name: Configure Plan AWS Credentials
-      if: ${{ steps.config.outputs.aws-region != '' && 
-              steps.config.outputs.aws-region != 'null' && 
-              steps.config.outputs.terraform-plan-role != '' && 
-              steps.config.outputs.terraform-plan-role != 'null' }}
+      if: ${{ steps.config.outputs.aws-region != '' &&
+        steps.config.outputs.aws-region != 'null' &&
+        steps.config.outputs.terraform-plan-role != '' &&
+        steps.config.outputs.terraform-plan-role != 'null' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}
@@ -204,13 +204,13 @@ runs:
       shell: bash
       run: |
         base_cmd="atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=${{ inputs.verbose }} --repo-path \"$GITHUB_WORKSPACE/base-ref\""
-        
+
         if [[ "${{ inputs.atmos-include-spacelift-admin-stacks }}" == "true" ]]; then
           base_cmd+=" --include-spacelift-admin-stacks=true"
         elif [[ "${{ inputs.atmos-include-dependents }}" == "true" ]]; then
           base_cmd+=" --include-dependents=true"
         fi
-        
+
         if [[ -n "${{ inputs.atmos-stack }}" ]]; then
           base_cmd+=" --stack=${{ inputs.atmos-stack }}"
         fi
@@ -218,7 +218,7 @@ runs:
         if [[ "${{ inputs.skip-atmos-functions }}" == "true" ]]; then
           base_cmd+=" --skip=terraform.output"
         fi
-        
+
         if [[ "${{ inputs.process-templates }}" == "false" ]]; then
           base_cmd+=" --process-templates=false"
         fi

--- a/action.yml
+++ b/action.yml
@@ -182,11 +182,11 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.atmos-include-spacelift-admin-stacks }}" == "true" ]]; then
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-spacelift-admin-stacks=true --stack="${{ inputs.atmos-stack }}"
+          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-spacelift-admin-stacks=true --stack=${{ inputs.atmos-stack }}
         elif [[ "${{ inputs.atmos-include-dependents }}" == "true" ]]; then
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-dependents=true --stack="${{ inputs.atmos-stack }}"
+          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-dependents=true --stack=${{ inputs.atmos-stack }}
         else
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --stack="${{ inputs.atmos-stack }}"
+          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --stack=${{ inputs.atmos-stack }}
         fi
         affected=$(jq -c '.' affected-stacks.json)
         printf "%s" "affected=$affected" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   atmos-version:
     description: The version of atmos to install
     required: false
-    default: ">= 1.80.0"
+    default: ">= 1.92.0"
   atmos-config-path:
     description: The path to the atmos.yaml file
     required: true
@@ -51,6 +51,10 @@ inputs:
     description: Include the `settings` section for each affected component
     required: false
     default: "false"
+  atmos-stack:
+    description: The stack to operate on
+    required: false
+    default: ""
   install-jq:
     description: Whether to install jq
     required: false
@@ -67,6 +71,7 @@ inputs:
     required: false
     description: "Number of nested matrices that should be returned as the output (from 1 to 3)"
     default: "2"
+  
 outputs:
   affected:
     description: The affected stacks
@@ -177,11 +182,11 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.atmos-include-spacelift-admin-stacks }}" == "true" ]]; then
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-spacelift-admin-stacks=true
+          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-spacelift-admin-stacks=true --stack="${{ inputs.atmos-stack }}"
         elif [[ "${{ inputs.atmos-include-dependents }}" == "true" ]]; then
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-dependents=true
+          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --include-dependents=true --stack="${{ inputs.atmos-stack }}"
         else
-          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref"
+          atmos describe affected --include-settings=${{ inputs.atmos-include-settings }} --file affected-stacks.json --verbose=true --repo-path "$GITHUB_WORKSPACE/base-ref" --stack="${{ inputs.atmos-stack }}"
         fi
         affected=$(jq -c '.' affected-stacks.json)
         printf "%s" "affected=$affected" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes changes to the `action.yml` file to improve the flexibility and functionality of the GitHub Action configuration. The most important changes include updating the `skip-checkout` input description and default value, modifying the `runs` section to conditionally skip the checkout step, and refining the checkout command for the base ref.

Improvements to input descriptions and defaults:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L13-R15): Updated the `skip-checkout` input description to include both head-ref and base-ref. Changed the default value of `skip-checkout` from single to double quotes for consistency.

Enhancements to the `runs` section:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R167): Added a conditional statement to the `actions/checkout@v4` step to skip the checkout if `skip-checkout` is set to 'true'.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L176-R176): Refined the checkout command for the base ref to conditionally force the checkout based on the `skip-checkout` input.

Other changes:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L106): Removed an unnecessary blank line in the `outputs` section.