### PR TITLE
chore: Set new Atmos Pro URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
   atmos-pro-base-url:
     description: The base URL of Atmos Pro
     required: false
-    default: "https://app.cloudposse.com"
+    default: "https://atmos-pro.com"
   atmos-pro-token:
     description: The API token to allow Atmos Pro to upload affected stacks
     required: false


### PR DESCRIPTION
## what
- Update default URL in action.yml to "https://atmos-pro.com"

## why
- New URL for Atmos Pro

## references
- atmos-pro.com
