### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/_test-negative.yml
+++ b/.github/workflows/_test-negative.yml
@@ -20,7 +20,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'false'
           actual: "${{ needs.test.outputs.result }}"

--- a/.github/workflows/test-matrix-2-levels.yml
+++ b/.github/workflows/test-matrix-2-levels.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -66,18 +66,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-ue2-root","stack_slug":"core-ue2-root-datadog-integration","affected":"component"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-gbl-audit","stack_slug":"core-gbl-audit-datadog-integration","affected":"component"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-datadog-integration","spacelift_stack":"core-gbl-auto-datadog-integration","affected":"component"},{"component":"infrastructure-cplive-plat","component_type":"terraform","component_path":"components/terraform/spacelift","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-infrastructure-cplive-plat","spacelift_stack":"core-gbl-auto-infrastructure-cplive-plat","affected":"stack.vars"},{"component":"infrastructure-cplive-core","component_type":"terraform","component_path":"components/terraform/spacelift","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-infrastructure-cplive-core","spacelift_stack":"core-gbl-auto-infrastructure-cplive-core","affected":"stack.vars"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"plat-gbl-prod","stack_slug":"plat-gbl-prod-datadog-integration","spacelift_stack":"plat-gbl-prod-datadog-integration","affected":"component"}]'
           actual: "${{ needs.test.outputs.affected }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":['
           actual: "${{ needs.test.outputs.matrix }}"
           comparison: contains
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":[{"name":"core-audit","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"core-gbl-audit\",\"stack_slug\":\"core-gbl-audit-datadog-integration\",\"affected\":\"component\"}]}"},{"name":"core-auto","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"core-gbl-auto\",\"stack_slug\":\"core-gbl-auto-datadog-integration\",\"spacelift_stack\":\"core-gbl-auto-datadog-integration\",\"affected\":\"component\"},{\"component\":\"infrastructure-cplive-core\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/spacelift\",\"stack\":\"core-gbl-auto\",\"stack_slug\":\"core-gbl-auto-infrastructure-cplive-core\",\"spacelift_stack\":\"core-gbl-auto-infrastructure-cplive-core\",\"affected\":\"stack.vars\"},{\"component\":\"infrastructure-cplive-plat\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/spacelift\",\"stack\":\"core-gbl-auto\",\"stack_slug\":\"core-gbl-auto-infrastructure-cplive-plat\",\"spacelift_stack\":\"core-gbl-auto-infrastructure-cplive-plat\",\"affected\":\"stack.vars\"}]}"},{"name":"core-root","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"core-ue2-root\",\"stack_slug\":\"core-ue2-root-datadog-integration\",\"affected\":\"component\"}]}"},{"name":"plat-prod","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"plat-gbl-prod\",\"stack_slug\":\"plat-gbl-prod-datadog-integration\",\"spacelift_stack\":\"plat-gbl-prod-datadog-integration\",\"affected\":\"component\"}]}"}]}'
           actual: "${{ needs.test.outputs.matrix }}"

--- a/.github/workflows/test-matrix-3-levels.yml
+++ b/.github/workflows/test-matrix-3-levels.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -66,18 +66,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-ue2-root","stack_slug":"core-ue2-root-datadog-integration","affected":"component"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-gbl-audit","stack_slug":"core-gbl-audit-datadog-integration","affected":"component"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-datadog-integration","spacelift_stack":"core-gbl-auto-datadog-integration","affected":"component"},{"component":"infrastructure-cplive-plat","component_type":"terraform","component_path":"components/terraform/spacelift","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-infrastructure-cplive-plat","spacelift_stack":"core-gbl-auto-infrastructure-cplive-plat","affected":"stack.vars"},{"component":"infrastructure-cplive-core","component_type":"terraform","component_path":"components/terraform/spacelift","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-infrastructure-cplive-core","spacelift_stack":"core-gbl-auto-infrastructure-cplive-core","affected":"stack.vars"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"plat-gbl-prod","stack_slug":"plat-gbl-prod-datadog-integration","spacelift_stack":"plat-gbl-prod-datadog-integration","affected":"component"}]'
           actual: "${{ needs.test.outputs.affected }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":['
           actual: "${{ needs.test.outputs.matrix }}"
           comparison: contains
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":[{"name":"core-audit","items":"{\"include\":[{\"name\":\"core-gbl-audit-datadog-integration - core-gbl-audit-datadog-integration\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"datadog-integration\\\",\\\"component_type\\\":\\\"terraform\\\",\\\"component_path\\\":\\\"components/terraform/datadog-integration\\\",\\\"stack\\\":\\\"core-gbl-audit\\\",\\\"stack_slug\\\":\\\"core-gbl-audit-datadog-integration\\\",\\\"affected\\\":\\\"component\\\"}]}\"}]}"},{"name":"core-auto","items":"{\"include\":[{\"name\":\"core-gbl-auto-datadog-integration - core-gbl-auto-infrastructure-cplive-plat\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"datadog-integration\\\",\\\"component_type\\\":\\\"terraform\\\",\\\"component_path\\\":\\\"components/terraform/datadog-integration\\\",\\\"stack\\\":\\\"core-gbl-auto\\\",\\\"stack_slug\\\":\\\"core-gbl-auto-datadog-integration\\\",\\\"spacelift_stack\\\":\\\"core-gbl-auto-datadog-integration\\\",\\\"affected\\\":\\\"component\\\"},{\\\"component\\\":\\\"infrastructure-cplive-core\\\",\\\"component_type\\\":\\\"terraform\\\",\\\"component_path\\\":\\\"components/terraform/spacelift\\\",\\\"stack\\\":\\\"core-gbl-auto\\\",\\\"stack_slug\\\":\\\"core-gbl-auto-infrastructure-cplive-core\\\",\\\"spacelift_stack\\\":\\\"core-gbl-auto-infrastructure-cplive-core\\\",\\\"affected\\\":\\\"stack.vars\\\"},{\\\"component\\\":\\\"infrastructure-cplive-plat\\\",\\\"component_type\\\":\\\"terraform\\\",\\\"component_path\\\":\\\"components/terraform/spacelift\\\",\\\"stack\\\":\\\"core-gbl-auto\\\",\\\"stack_slug\\\":\\\"core-gbl-auto-infrastructure-cplive-plat\\\",\\\"spacelift_stack\\\":\\\"core-gbl-auto-infrastructure-cplive-plat\\\",\\\"affected\\\":\\\"stack.vars\\\"}]}\"}]}"},{"name":"core-root","items":"{\"include\":[{\"name\":\"core-ue2-root-datadog-integration - core-ue2-root-datadog-integration\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"datadog-integration\\\",\\\"component_type\\\":\\\"terraform\\\",\\\"component_path\\\":\\\"components/terraform/datadog-integration\\\",\\\"stack\\\":\\\"core-ue2-root\\\",\\\"stack_slug\\\":\\\"core-ue2-root-datadog-integration\\\",\\\"affected\\\":\\\"component\\\"}]}\"}]}"},{"name":"plat-prod","items":"{\"include\":[{\"name\":\"plat-gbl-prod-datadog-integration - plat-gbl-prod-datadog-integration\",\"items\":\"{\\\"include\\\":[{\\\"component\\\":\\\"datadog-integration\\\",\\\"component_type\\\":\\\"terraform\\\",\\\"component_path\\\":\\\"components/terraform/datadog-integration\\\",\\\"stack\\\":\\\"plat-gbl-prod\\\",\\\"stack_slug\\\":\\\"plat-gbl-prod-datadog-integration\\\",\\\"spacelift_stack\\\":\\\"plat-gbl-prod-datadog-integration\\\",\\\"affected\\\":\\\"component\\\"}]}\"}]}"}]}'
           actual: "${{ needs.test.outputs.matrix }}"

--- a/.github/workflows/test-no-changes.yml
+++ b/.github/workflows/test-no-changes.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -64,12 +64,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[]'
           actual: "${{ needs.test.outputs.affected }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'false'
           actual: "${{ needs.test.outputs.has-affected-stacks }}"

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -65,18 +65,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-ue2-root","stack_slug":"core-ue2-root-datadog-integration","affected":"component"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-gbl-audit","stack_slug":"core-gbl-audit-datadog-integration","affected":"component"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-datadog-integration","spacelift_stack":"core-gbl-auto-datadog-integration","affected":"component"},{"component":"infrastructure-cplive-plat","component_type":"terraform","component_path":"components/terraform/spacelift","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-infrastructure-cplive-plat","spacelift_stack":"core-gbl-auto-infrastructure-cplive-plat","affected":"stack.vars"},{"component":"infrastructure-cplive-core","component_type":"terraform","component_path":"components/terraform/spacelift","stack":"core-gbl-auto","stack_slug":"core-gbl-auto-infrastructure-cplive-core","spacelift_stack":"core-gbl-auto-infrastructure-cplive-core","affected":"stack.vars"},{"component":"datadog-integration","component_type":"terraform","component_path":"components/terraform/datadog-integration","stack":"plat-gbl-prod","stack_slug":"plat-gbl-prod-datadog-integration","spacelift_stack":"plat-gbl-prod-datadog-integration","affected":"component"}]'
           actual: "${{ needs.test.outputs.affected }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":['
           actual: "${{ needs.test.outputs.matrix }}"
           comparison: contains
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"include":[{"name":"core-audit","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"core-gbl-audit\",\"stack_slug\":\"core-gbl-audit-datadog-integration\",\"affected\":\"component\"}]}"},{"name":"core-auto","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"core-gbl-auto\",\"stack_slug\":\"core-gbl-auto-datadog-integration\",\"spacelift_stack\":\"core-gbl-auto-datadog-integration\",\"affected\":\"component\"},{\"component\":\"infrastructure-cplive-core\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/spacelift\",\"stack\":\"core-gbl-auto\",\"stack_slug\":\"core-gbl-auto-infrastructure-cplive-core\",\"spacelift_stack\":\"core-gbl-auto-infrastructure-cplive-core\",\"affected\":\"stack.vars\"},{\"component\":\"infrastructure-cplive-plat\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/spacelift\",\"stack\":\"core-gbl-auto\",\"stack_slug\":\"core-gbl-auto-infrastructure-cplive-plat\",\"spacelift_stack\":\"core-gbl-auto-infrastructure-cplive-plat\",\"affected\":\"stack.vars\"}]}"},{"name":"core-root","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"core-ue2-root\",\"stack_slug\":\"core-ue2-root-datadog-integration\",\"affected\":\"component\"}]}"},{"name":"plat-prod","items":"{\"include\":[{\"component\":\"datadog-integration\",\"component_type\":\"terraform\",\"component_path\":\"components/terraform/datadog-integration\",\"stack\":\"plat-gbl-prod\",\"stack_slug\":\"plat-gbl-prod-datadog-integration\",\"spacelift_stack\":\"plat-gbl-prod-datadog-integration\",\"affected\":\"component\"}]}"}]}'
           actual: "${{ needs.test.outputs.matrix }}"

--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
       with:
         node-version: 24
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       if: ${{ inputs.skip-checkout != 'true' }}
       with:
         ref: ${{ inputs.head-ref }}
@@ -165,7 +165,7 @@ runs:
     # atmos describe affected requires the main branch of the git repo to be present on disk so it can compare the
     # current branch to it to determine the affected stacks. This is different from a file-based git diff in that we
     # look at the contents of the stack files to determine if any have changed.
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       if: ${{ inputs.skip-checkout != 'true' }}
       with:
         ref: ${{ inputs.default-branch }}


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows and `action.yml` to versions running on the
  Node 24 runtime, SHA-pinned with precise version comments:
  * `actions/checkout@v6` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #91
Supersedes #90
Supersedes #87 (partially — the checkout and assert-action pins)

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## still on Node 20

* `cloudposse-github-actions/install-gh-releases@v1` — no Node 24 release exists yet
* Left as-is (already on current majors / outside this upgrade matrix):
  `actions/setup-node@v6`, `hashicorp/setup-terraform@v4`,
  `aws-actions/configure-aws-credentials@v6` (its `mask-aws-account-id: false` is already a
  valid boolean), `cloudposse/github-action-setup-atmos@49625d9f # v3` (already SHA-pinned;
  Renovate #92 proposes the v3.5.0 digest), `cloudposse/github-action-matrix-extended@v0`
